### PR TITLE
Add default value for maximumAge in DOBValidator

### DIFF
--- a/library/src/main/java/com/paulmarkcastillo/pmctoolbox/validators/DOBValidator.kt
+++ b/library/src/main/java/com/paulmarkcastillo/pmctoolbox/validators/DOBValidator.kt
@@ -6,7 +6,7 @@ import java.util.regex.Pattern
 
 class DOBValidator(
     private val minimumAge: Int,
-    private val maximumAge: Int
+    private val maximumAge: Int = 0
 ) : BaseValidator() {
 
     // This regex check for valid date with a format of MM/dd/yyyy


### PR DESCRIPTION
Added default value instead of removing parameter, in case maximum age will be needed in the future.